### PR TITLE
Postprocessing and analysis scripts for prelim, valence-related analyses

### DIFF
--- a/code/analysisPrelim.R
+++ b/code/analysisPrelim.R
@@ -1,6 +1,10 @@
 # Preliminary Analyses: readAloud-valence-alpha
 # Author: Jessica M. Alexander
-# Last Updated: 2022-04-19
+# Last Updated: 2022-04-21
+
+### SETTING UP
+library(ggplot2)
+
 
 ### GENERAL EFFECT OF PASSAGE VALENCE ON READING BEHAVIOR (BETWEEN-SUBJECT)
 ### Hypothesis 1A:
@@ -13,50 +17,50 @@
 ## PosOrNeg : indication of whether the first passage half is positive or negative (categorical: pos2neg, neg2pos)
 
 ## dependent variables
-## syllPerSec : syllables coded for the passage half / length of reading in seconds (continuous)
-## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the passage half (continuous)
-## vocalPitch : pitch rating from Praat for the passage half (continuous)
+## syllPerSec_firstHalf : syllables coded for the first passage half / length of reading in seconds (continuous)
+## percDisfluent_firstHalf : number of syllables produced with some kind of disfluency / syllables coded for the first passage half (continuous)
+## vocalPitch_firstHalf : pitch rating from Praat for the first passage half (continuous)
 
 
 ###### categorical independent variables
 # syllPerSec ~ PosOrNeg
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec_firstHalf)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$syllPerSec, DATA[PosOrNeg=="neg2pos"]$syllPerSec, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$syllPerSec_firstHalf, DATA[DATA$PosOrNeg=="neg2pos",]$syllPerSec_firstHalf, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 # percDisfluent ~ PosOrNeg
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent_firstHalf)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$percDisfluent, DATA[PosOrNeg=="neg2pos"]$percDisfluent, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$percDisfluent_firstHalf, DATA[DATA$PosOrNeg=="neg2pos",]$percDisfluent_firstHalf, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 # vocalPitch ~ PosOrNeg
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch_firstHalf)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$vocalPitch, DATA[PosOrNeg=="neg2pos"]$vocalPitch, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$vocalPitch_firstHalf, DATA[DATA$PosOrNeg=="neg2pos",]$vocalPitch_firstHalf, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 ###### continuous independent variables
 # syllPerSec ~ liwcScore x PreOrPost
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=syllPerSec)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+ggplot(data=DATA, aes(x=liwcScore, y=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
 # model
-lm(syllPerSec ~ liwcScore, data=DATA)
+lm(syllPerSec_firstHalf ~ liwcScore, data=DATA)
 # individual t-tests TBD
 
 # percDisfluent ~ liwcScore x PreOrPost
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=percDisfluent)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+ggplot(data=DATA, aes(x=liwcScore, y=percDisfluent_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
 # model
-lm(percDisfluent ~ liwcScore, data=DATA)
+lm(percDisfluent_firstHalf ~ liwcScore, data=DATA)
 # individual t-tests TBD
 
 # vocalPitch ~ liwcScore x PreOrPost
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=vocalPitch)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+ggplot(data=DATA, aes(x=liwcScore, y=vocalPitch_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
 # model
-lm(vocalPitch ~ liwcScore, data=DATA)
+lm(vocalPitch_firstHalf ~ liwcScore, data=DATA)
 # individual t-tests TBD
 
 
@@ -72,56 +76,56 @@ lm(vocalPitch ~ liwcScore, data=DATA)
 ## liwcScore : emotional tone rating from LIWC for the passage half (continuous)
 ## PosOrNeg : indication of whether the passage half is positive or negative (categorical: pos2neg, neg2pos)
 ## bmis_scrdVal : participant mood score (continuous)
-## SubjectMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
+## subMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
 
 ## dependent variables
-## syllPerSec : syllables coded for the passage half / length of reading in seconds (continuous)
-## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the passage half (continuous)
-## vocalPitch : pitch rating from Praat for the passage half (continuous)
+## syllPerSec_firstHalf : syllables coded for the first passage half / length of reading in seconds (continuous)
+## percDisfluent_firstHalf : number of syllables produced with some kind of disfluency / syllables coded for the first passage half (continuous)
+## vocalPitch_firstHalf : pitch rating from Praat for the first passage half (continuous)
 
 ###### categorical independent variables
-# syllPerSec ~ PosOrNeg x SubjectMood
+# syllPerSec ~ PosOrNeg x subMood
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec_firstHalf, fill=subMood)) + geom_boxplot()
 # model
-aov(syllPerSec ~ PosOrNeg + SubjectMood, data=DATA)
+aov(syllPerSec_firstHalf ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
-# percDisfluent ~ PosOrNeg x SubjectMood
+# percDisfluent ~ PosOrNeg x subMood
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent_firstHalf, fill=subMood)) + geom_boxplot()
 # model
-aov(percDisfluent ~ PosOrNeg + SubjectMood, data=DATA)
+aov(percDisfluent_firstHalf ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
-# vocalPitch ~ PosOrNeg x SubjectMood
+# vocalPitch ~ PosOrNeg x subMood
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch_firstHalf, fill=subMood)) + geom_boxplot()
 # model
-aov(vocalPitch ~ PosOrNeg + SubjectMood, data=DATA)
+aov(vocalPitch_firstHalf ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
 
 ###### continuous independent variables
 # syllPerSec ~ liwcScore x bmis_scrdVal
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=syllPerSec)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
 # model
-lm(syllPerSec ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+lm(syllPerSec_firstHalf ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
 # individual t-tests TBD
 
 # percDisfluent ~ liwcScore x bmis_scrdVal
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=percDisfluent)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=percDisfluent_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
 # model
-lm(percDisfluent ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+lm(percDisfluent_firstHalf ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
 # individual t-tests TBD
 
 # vocalPitch ~ liwcScore x bmis_scrdVal
 # plot
-ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=vocalPitch)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=vocalPitch_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
 # model
-lm(vocalPitch ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+lm(vocalPitch_firstHalf ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
 # individual t-tests TBD
 
 
@@ -132,53 +136,53 @@ lm(vocalPitch ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA
 
 ## independent variables
 ## PosOrNeg : indication of the directionality of the passage switch (categorical: pos2neg, neg2pos)
-## SubjectMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
+## subMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
 
 ## dependent variables
-## syllPerSec : syllables coded for the switch group / length of reading in seconds (continuous)
-## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the switch group (continuous)
-## vocalPitch : pitch rating from Praat for the switch group (continuous)
+## syllPerSec_switch : syllables coded for the switch group / length of reading in seconds (continuous)
+## percDisfluent_switch : number of syllables produced with some kind of disfluency / syllables coded for the switch group (continuous)
+## vocalPitch_switch : pitch rating from Praat for the switch group (continuous)
 
-# straight comparison of switches
+# straight comparison of pos2neg and neg2pos switch groups
 #syllPerSec
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec_switch)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$syllPerSec, DATA[PosOrNeg=="neg2pos"]$syllPerSec, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$syllPerSec_switch, DATA[DATA$PosOrNeg=="neg2pos",]$syllPerSec_switch, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 #percDisfluent
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent_switch)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$percDisfluent, DATA[PosOrNeg=="neg2pos"]$percDisfluent, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$percDisfluent_switch, DATA[DATA$PosOrNeg=="neg2pos",]$percDisfluent_switch, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 #vocalPitch
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch_switch)) + geom_boxplot()
 # model
-t.test(DATA[PosOrNeg=="pos2neg"]$vocalPitch, DATA[PosOrNeg=="neg2pos"]$vocalPitch, alternative="two-sided", paired=FALSE, conf.level=0.95)
+t.test(DATA[DATA$PosOrNeg=="pos2neg",]$vocalPitch_switch, DATA[DATA$PosOrNeg=="neg2pos",]$vocalPitch_switch, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
 
 # mood-congruency on switches
 #syllPerSec
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec_switch, fill=subMood)) + geom_boxplot()
 # model
-aov(syllPerSec ~ PosOrNeg + SubjectMood, data=DATA)
+aov(syllPerSec_switch ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
 #percDisfluent
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent_switch, fill=subMood)) + geom_boxplot()
 # model
-aov(percDisfluent ~ PosOrNeg + SubjectMood, data=DATA)
+aov(percDisfluent_switch ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
 #vocalPitch
 # plot
-ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch, fill=SubjectMood)) + geom_boxplot()
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch_switch, fill=subMood)) + geom_boxplot()
 # model
-aov(vocalPitch ~ PosOrNeg + SubjectMood, data=DATA)
+aov(vocalPitch_switch ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
 

--- a/code/analysisPrelim.R
+++ b/code/analysisPrelim.R
@@ -14,6 +14,7 @@ library(ggplot2)
 
 ## independent variables
 ## liwcScore : emotional tone rating from LIWC for the first half of the passage (continuous)
+## warrinerAvg : average of lexical valence scores from Warriner et al. 2013 (continuous)
 ## PosOrNeg : indication of whether the first passage half is positive or negative (categorical: pos2neg, neg2pos)
 
 ## dependent variables
@@ -41,7 +42,7 @@ ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch_firstHalf)) + geom_boxplot()
 # model
 t.test(DATA[DATA$PosOrNeg=="pos2neg",]$vocalPitch_firstHalf, DATA[DATA$PosOrNeg=="neg2pos",]$vocalPitch_firstHalf, alternative="two.sided", paired=FALSE, conf.level=0.95)
 
-###### continuous independent variables
+###### continuous independent variables (LIWC)
 # syllPerSec ~ liwcScore x PreOrPost
 # plot
 ggplot(data=DATA, aes(x=liwcScore, y=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
@@ -63,6 +64,28 @@ ggplot(data=DATA, aes(x=liwcScore, y=vocalPitch_firstHalf)) + geom_point() + geo
 lm(vocalPitch_firstHalf ~ liwcScore, data=DATA)
 # individual t-tests TBD
 
+###### continuous independent variables (Warriner)
+# syllPerSec ~ warrinerAvg x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(syllPerSec_firstHalf ~ warrinerAvg, data=DATA)
+# individual t-tests TBD
+
+# percDisfluent ~ warrinerAvg x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=percDisfluent_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(percDisfluent_firstHalf ~ warrinerAvg, data=DATA)
+# individual t-tests TBD
+
+# vocalPitch ~ warrinerAvg x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=vocalPitch_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(vocalPitch_firstHalf ~ warrinerAvg, data=DATA)
+# individual t-tests TBD
+
 
 ### EFFECT OF PASSAGE VALENCE AND MOOD CONGRUENCY ON READING BEHAVIOR (WITHIN-SUBJECT)
 ### Hypothesis 1B:
@@ -74,6 +97,7 @@ lm(vocalPitch_firstHalf ~ liwcScore, data=DATA)
 
 ## independent variables
 ## liwcScore : emotional tone rating from LIWC for the passage half (continuous)
+## warrinerAvg : average of lexical valence scores from Warriner et al. 2013 (continuous)
 ## PosOrNeg : indication of whether the passage half is positive or negative (categorical: pos2neg, neg2pos)
 ## bmis_scrdVal : participant mood score (continuous)
 ## subMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
@@ -106,7 +130,7 @@ aov(vocalPitch_firstHalf ~ PosOrNeg + subMood, data=DATA)
 # post-hoc comparisons TBD
 
 
-###### continuous independent variables
+###### continuous independent variables (LIWC)
 # syllPerSec ~ liwcScore x bmis_scrdVal
 # plot
 ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
@@ -126,6 +150,28 @@ lm(percDisfluent_firstHalf ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal +
 ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=vocalPitch_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
 # model
 lm(vocalPitch_firstHalf ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+###### continuous independent variables (Warriner)
+# syllPerSec ~ warrinerAvg x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=bmis_scrdVal, color=syllPerSec_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(syllPerSec_firstHalf ~ warrinerAvg + bmis_scrdVal + warrinerAvg:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+# percDisfluent ~ warrinerAvg x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=bmis_scrdVal, color=percDisfluent_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(percDisfluent_firstHalf ~ warrinerAvg + bmis_scrdVal + warrinerAvg:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+# vocalPitch ~ warrinerAvg x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=warrinerAvg, y=bmis_scrdVal, color=vocalPitch_firstHalf)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(vocalPitch_firstHalf ~ warrinerAvg + bmis_scrdVal + warrinerAvg:bmis_scrdVal + 0, data=DATA)
 # individual t-tests TBD
 
 

--- a/code/analysisPrelim.R
+++ b/code/analysisPrelim.R
@@ -1,0 +1,194 @@
+# Preliminary Analyses: readAloud-valence-alpha
+# Author: Jessica M. Alexander
+# Last Updated: 2022-04-19
+
+### GENERAL EFFECT OF PASSAGE VALENCE ON READING BEHAVIOR (BETWEEN-SUBJECT)
+### Hypothesis 1A:
+##### A: no difference in reading speed/disfluency between positive and negative passages
+##### B: positivity bias: faster speeds and fewer disfluencies on positive passages relative to negative
+#### Exploratory: acoustic behavioral measure of pitch
+
+## independent variables
+## liwcScore : emotional tone rating from LIWC for the first half of the passage (continuous)
+## PosOrNeg : indication of whether the first passage half is positive or negative (categorical: pos2neg, neg2pos)
+
+## dependent variables
+## syllPerSec : syllables coded for the passage half / length of reading in seconds (continuous)
+## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the passage half (continuous)
+## vocalPitch : pitch rating from Praat for the passage half (continuous)
+
+
+###### categorical independent variables
+# syllPerSec ~ PosOrNeg
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$syllPerSec, DATA[PosOrNeg=="neg2pos"]$syllPerSec, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+# percDisfluent ~ PosOrNeg
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$percDisfluent, DATA[PosOrNeg=="neg2pos"]$percDisfluent, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+# vocalPitch ~ PosOrNeg
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$vocalPitch, DATA[PosOrNeg=="neg2pos"]$vocalPitch, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+###### continuous independent variables
+# syllPerSec ~ liwcScore x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=syllPerSec)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(syllPerSec ~ liwcScore, data=DATA)
+# individual t-tests TBD
+
+# percDisfluent ~ liwcScore x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=percDisfluent)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(percDisfluent ~ liwcScore, data=DATA)
+# individual t-tests TBD
+
+# vocalPitch ~ liwcScore x PreOrPost
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=vocalPitch)) + geom_point() + geom_smooth(method="lm", se=FALSE)
+# model
+lm(vocalPitch ~ liwcScore, data=DATA)
+# individual t-tests TBD
+
+
+### EFFECT OF PASSAGE VALENCE AND MOOD CONGRUENCY ON READING BEHAVIOR (WITHIN-SUBJECT)
+### Hypothesis 1B:
+##### A: mood-congruency: faster speeds and fewer disfluencies on passages that better match mood state
+##### B: mood-congruency + positivity advantage: best performance on positive passages in good mood
+##### C: negativity dampening: similar performance in negative mood on positive and negative passages
+##### D: creativity trap: faster speed but more disfluencies in positive mood
+#### Exploratory: acoustic behavioral measure of pitch
+
+## independent variables
+## liwcScore : emotional tone rating from LIWC for the passage half (continuous)
+## PosOrNeg : indication of whether the passage half is positive or negative (categorical: pos2neg, neg2pos)
+## bmis_scrdVal : participant mood score (continuous)
+## SubjectMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
+
+## dependent variables
+## syllPerSec : syllables coded for the passage half / length of reading in seconds (continuous)
+## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the passage half (continuous)
+## vocalPitch : pitch rating from Praat for the passage half (continuous)
+
+###### categorical independent variables
+# syllPerSec ~ PosOrNeg x SubjectMood
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(syllPerSec ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+# percDisfluent ~ PosOrNeg x SubjectMood
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(percDisfluent ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+# vocalPitch ~ PosOrNeg x SubjectMood
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(vocalPitch ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+
+###### continuous independent variables
+# syllPerSec ~ liwcScore x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=syllPerSec)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(syllPerSec ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+# percDisfluent ~ liwcScore x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=percDisfluent)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(percDisfluent ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+# vocalPitch ~ liwcScore x bmis_scrdVal
+# plot
+ggplot(data=DATA, aes(x=liwcScore, y=bmis_scrdVal, color=vocalPitch)) + geom_point() + geom_smooth(method="lm", se=FALSE) + scale_color_viridis()
+# model
+lm(vocalPitch ~ liwcScore + bmis_scrdVal + liwcScore:bmis_scrdVal + 0, data=DATA)
+# individual t-tests TBD
+
+
+### Hypothesis 2:
+##### A: positive activation and negative compensation: fewer disfluencies in negative>positive switches than reverse
+##### B: general surprisal: similar disfluency rates positive>negative and negative>positive
+##### C: mood-incongruent surprisal: enhanced disfluency rates when hitting switch that conflicts with current mood state
+
+## independent variables
+## PosOrNeg : indication of the directionality of the passage switch (categorical: pos2neg, neg2pos)
+## SubjectMood : indication of whether participant mood falls above/below the midmark on bmis_scrdVal (categorical: posMood, negMood)
+
+## dependent variables
+## syllPerSec : syllables coded for the switch group / length of reading in seconds (continuous)
+## percDisfluent : number of syllables produced with some kind of disfluency / syllables coded for the switch group (continuous)
+## vocalPitch : pitch rating from Praat for the switch group (continuous)
+
+# straight comparison of switches
+#syllPerSec
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$syllPerSec, DATA[PosOrNeg=="neg2pos"]$syllPerSec, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+#percDisfluent
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$percDisfluent, DATA[PosOrNeg=="neg2pos"]$percDisfluent, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+#vocalPitch
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch)) + geom_boxplot()
+# model
+t.test(DATA[PosOrNeg=="pos2neg"]$vocalPitch, DATA[PosOrNeg=="neg2pos"]$vocalPitch, alternative="two-sided", paired=FALSE, conf.level=0.95)
+
+
+# mood-congruency on switches
+#syllPerSec
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=syllPerSec, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(syllPerSec ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+#percDisfluent
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=percDisfluent, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(percDisfluent ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+#vocalPitch
+# plot
+ggplot(data=DATA, aes(x=PosOrNeg, y=vocalPitch, fill=SubjectMood)) + geom_boxplot()
+# model
+aov(vocalPitch ~ PosOrNeg + SubjectMood, data=DATA)
+# post-hoc comparisons TBD
+
+
+### GENERAL EFFECT OF PASSAGE VALENCE ON READING BEHAVIOR (BETWEEN-SUBJECT)
+### Hypothesis 3:
+##### A: PES and PIA will be accentuated in positive passages versus negative passages.
+##### B: RT and accuracy following errors will be slower/higher than the associated post-correct measures.
+
+## independent variables
+## TBD
+
+## dependent variables
+## TBD

--- a/code/postprocessing/postprocessPrelim.R
+++ b/code/postprocessing/postprocessPrelim.R
@@ -1,0 +1,243 @@
+# Preliminary Analyses: readAloud-valence-alpha
+# Author: Jessica M. Alexander
+# Last Updated: 2022-04-21
+
+### SECTION 1: SETTING UP
+library(readxl)
+
+#select participants to include in output file
+subs <- c(150001, 150004)
+
+#set up date for output file naming
+today <- Sys.Date()
+today <- format(today, "%Y%m%d")
+
+#set up directories for input/output data
+#hpc
+#passagechar_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/materials/readAloud-ldt/stimuli/readAloud/readAloud-stimuli_characteristics.xlsx'
+#redcap_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/sourcedata/checked/redcap/202201v0readAloudval_DATA_2022-04-20_0854.csv'
+#challengeAcc_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220419.csv'
+#timing_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220419.csv'
+#pitch_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220419.csv''
+#disfluencies_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220419.csv'
+#out_path <- '/home/data/NDClab/datasets/readAloud-valence-alpha/derivatives/'
+#local
+passagechar_file <- '/Users/jalexand/github/readAloud-valence-dataset/materials/readAloud-ldt/stimuli/readAloud/readAloud-stimuli_characteristics.xlsx'
+redcap_file <- '/Users/jalexand/github/readAloud-valence-dataset/sourcedata/checked/redcap/202201v0readAloudval_DATA_2022-04-20_0854.csv'
+challengeAcc_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220419.csv'
+timing_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220419.csv'
+pitch_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220419.csv'
+disfluencies_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220419.csv'
+out_path <- '/Users/jalexand/github/readAloud-valence-alpha/derivatives/'
+
+#load data files
+passageDat <- read.xlsx(passagechar_file, sheet="passages")
+redcapDat <- read.csv(redcap_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
+challengeDat <- read.csv(challengeAcc_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
+timingDat <- read.csv(timing_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
+pitchDat <- read.csv(pitch_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
+disfluenciesDat <- read.csv(disfluencies_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
+
+#create dataframes for storing output data and define output file name
+prelimPassageSummaryDat <- data.frame(matrix(ncol=30, nrow=0))
+colnames(prelimPassageSummaryDat) <- c("id",
+                                       "demo_b_sex",
+                                       "demo_b_eng",
+                                       "demo_b_langhis",
+                                       "demo_b_ageen",
+                                       "demo_b_diagkidnow",
+                                       "demo_b_diateennow",
+                                       "demo_b_diagadnow",
+                                       "bmis_scrdVal",
+                                       "subMood",
+                                       "phq8_scrdTotal",
+                                       "challengeAcc",
+                                       "passage",
+                                       "liwcScore",
+                                       "PosOrNeg",
+                                       "syllPerSec_firstHalf",
+                                       "syllPerSec_prePREswitch",
+                                       "syllPerSec_preswitch",
+                                       "syllPerSec_switch",
+                                       "syllPerSec_postswitch",
+                                       "vocalPitch_firstHalf",
+                                       "vocalPitch_prePREswitch",
+                                       "vocalPitch_preswitch",
+                                       "vocalPitch_switch",
+                                       "vocalPitch_postswitch",
+                                       "percDisfluent_firstHalf",
+                                       "percDisfluent_prePREswitch",
+                                       "percDisfluent_preswitch",
+                                       "percDisfluent_switch",
+                                       "percDisfluent_postswitch")
+prelimPassage_out <- paste("postprocess_subject-by-passage_", today, ".csv", sep="", collapse=NULL)
+
+prelimSubjectSummaryDat <- data.frame(matrix(ncol=29, nrow=0))
+colnames(prelimSubjectSummaryDat) <- colnames(prelimPassageSummaryDat)[-13] #drop only 'passage' as collapsing across passages
+prelimSubject_out <- paste("postprocess_subject-by-valence_", today, ".csv", sep="", collapse=NULL)
+
+### SECTION 2: START PARTICIPANT LOOP AND READ IN PARTICIPANT DATA
+for(i in 1:length(subs)){
+  id <- subs[i]
+  redcap_row <- match(id, redcapDat$record_id)
+  
+  demo_b_sex <- redcapDat$demo_b_sex_s1_r1_e1[redcap_row]
+  demo_b_eng <- redcapDat$demo_b_eng_s1_r1_e1[redcap_row]
+  demo_b_langhis <- redcapDat$demo_b_langhis_s1_r1_e1[redcap_row]
+  demo_b_ageen <- redcapDat$demo_b_ageen_s1_r1_e1[redcap_row]
+  demo_b_diagkidnow <- redcapDat$demo_b_diagkidnow_s1_r1_e1[redcap_row]
+  demo_b_diateennow <- redcapDat$demo_b_diateennow_s1_r1_e1[redcap_row]
+  demo_b_diagadnow <- redcapDat$demo_b_diagadnow_s1_r1_e1[redcap_row]
+  
+  bmis_scrdVal <- redcapDat$bmis_scrdVal_s1_r1_e1[redcap_row]
+  if (bmis_scrdVal<=40){subMood <- "negMood"} else {subMood <- "posMood"}
+  
+  phq8_scrdTotal <- redcapDat$phq8_scrdTotal_s1_r1_e1[redcap_row]
+  
+  challengeAcc <- challengeDat[match(id, challengeDat$id),2]
+  
+  ### SECTION 3: TRIM PREPROCESSED FILES DOWN TO SUBJECT ID
+  timingDatTrim <- timingDat[timingDat$id==id,]
+  pitchDatTrim <- pitchDat[timingDat$id==id,]
+  disfluenciesDatTrim <- disfluenciesDat[timingDat$id==id,]
+  
+  ### SECTION 4: START PASSAGE LOOP AND READ IN PASSAGE CHARACTERISTICS AND BEHAVIORAL DATA
+  for (j in 1:nrow(timingDatTrim)){
+    passage <- timingDatTrim$passage[j]
+    passagechars_row <- match(passage, passageDat$passage)
+    liwcScore <- passageDat$emoToneALL[passagechars_row]
+    PosOrNeg <- passageDat$switchType[passagechars_row]
+    
+    passage_timing_row <- match(passage, timingDatTrim$passage)
+    syllPerSec_firstHalf <- timingDatTrim$syllPerSec_firstHalf[passage_timing_row]
+    syllPerSec_prePREswitch <- timingDatTrim$syllPerSec_prePREswitch[passage_timing_row]
+    syllPerSec_preswitch <- timingDatTrim$syllPerSec_preswitch[passage_timing_row]
+    syllPerSec_switch <- timingDatTrim$syllPerSec_switch[passage_timing_row]
+    syllPerSec_postswitch <- timingDatTrim$syllPerSec_postswitch[passage_timing_row]
+    
+    passage_pitch_row <- match(passage, pitchDatTrim$passage)
+    vocalPitch_firstHalf <- pitchDatTrim$vocalPitch_firstHalf[passage_pitch_row]
+    vocalPitch_prePREswitch <- pitchDatTrim$vocalPitch_prePREswitch[passage_pitch_row]
+    vocalPitch_preswitch <- pitchDatTrim$vocalPitch_preswitch[passage_pitch_row]
+    vocalPitch_switch <- pitchDatTrim$vocalPitch_switch[passage_pitch_row]
+    vocalPitch_postswitch <- pitchDatTrim$vocalPitch_postswitch[passage_pitch_row]
+    
+    passage_disfluences_row <- match(passage, disfluenciesDatTrim$passage)
+    percDisfluent_firstHalf <- disfluenciesDatTrim$percDisfluent_firstHalf[passage_disfluences_row]
+    percDisfluent_prePREswitch <- disfluenciesDatTrim$percDisfluent_prePREswitch[passage_disfluences_row]
+    percDisfluent_preswitch <- disfluenciesDatTrim$percDisfluent_preswitch[passage_disfluences_row]
+    percDisfluent_switch <- disfluenciesDatTrim$percDisfluent_switch[passage_disfluences_row]
+    percDisfluent_postswitch <- disfluenciesDatTrim$percDisfluent_postswitch[passage_disfluences_row]
+    
+    ### SECTION 4: STORE OUTPUT DATA IN SUMMARY MATRIX
+    prelimPassageSummaryDat[nrow(prelimPassageSummaryDat) + 1,] <-c(id,
+                                                                    demo_b_sex,
+                                                                    demo_b_eng,
+                                                                    demo_b_langhis,
+                                                                    demo_b_ageen,
+                                                                    demo_b_diagkidnow,
+                                                                    demo_b_diateennow,
+                                                                    demo_b_diagadnow,
+                                                                    bmis_scrdVal,
+                                                                    subMood,
+                                                                    phq8_scrdTotal,
+                                                                    challengeAcc,
+                                                                    passage,
+                                                                    liwcScore,
+                                                                    PosOrNeg,
+                                                                    syllPerSec_firstHalf,
+                                                                    syllPerSec_prePREswitch,
+                                                                    syllPerSec_preswitch,
+                                                                    syllPerSec_switch,
+                                                                    syllPerSec_postswitch,
+                                                                    vocalPitch_firstHalf,
+                                                                    vocalPitch_prePREswitch,
+                                                                    vocalPitch_preswitch,
+                                                                    vocalPitch_switch,
+                                                                    vocalPitch_postswitch,
+                                                                    percDisfluent_firstHalf,
+                                                                    percDisfluent_prePREswitch,
+                                                                    percDisfluent_preswitch,
+                                                                    percDisfluent_switch,
+                                                                    percDisfluent_postswitch)
+  }
+}
+
+
+### SECTION 5: LOOP BACK OVER SUBJECTS TO COLLAPSE prelimPassageSummaryDat ACROSS PASSAGES
+for(k in 1:length(subs)){
+  subjectDat <- prelimPassageSummaryDat[prelimPassageSummaryDat$id==subs[k],]
+  
+  #loop over switch types to extract means for each
+  switchTypes <- c("pos2neg", "neg2pos")
+  for(n in 1:length(switchTypes)){
+    subjectDatVal <- subjectDat[subjectDat$PosOrNeg==switchTypes[n],]
+    
+    id <- subs[k]
+    demo_b_sex <- subjectDatVal$demo_b_sex[1]
+    demo_b_eng <- subjectDatVal$demo_b_eng[1]
+    demo_b_langhis <- subjectDatVal$demo_b_langhis[1]
+    demo_b_ageen <- subjectDatVal$demo_b_ageen[1]
+    demo_b_diagkidnow <- subjectDatVal$demo_b_diagkidnow[1]
+    demo_b_diateennow <- subjectDatVal$demo_b_diateennow[1]
+    demo_b_diagadnow <- subjectDatVal$demo_b_diagadnow[1]
+    bmis_scrdVal <- subjectDatVal$bmis_scrdVal[1]
+    subMood <- subjectDatVal$subMood[1]
+    phq8_scrdTotal <- subjectDatVal$phq8_scrdTotal[1]
+    challengeAcc <- subjectDatVal$challengeAcc[1]
+    liwcScore <- mean(as.numeric(subjectDatVal$liwcScore))
+    PosOrNeg <- switchTypes[n]
+    syllPerSec_firstHalf <- mean(as.numeric(subjectDatVal$syllPerSec_firstHalf))
+    syllPerSec_prePREswitch <- mean(as.numeric(subjectDatVal$syllPerSec_prePREswitch))
+    syllPerSec_preswitch <- mean(as.numeric(subjectDatVal$syllPerSec_preswitch))
+    syllPerSec_switch <- mean(as.numeric(subjectDatVal$syllPerSec_switch))
+    syllPerSec_postswitch <- mean(as.numeric(subjectDatVal$syllPerSec_postswitch))
+    vocalPitch_firstHalf <- mean(as.numeric(subjectDatVal$vocalPitch_firstHalf))
+    vocalPitch_prePREswitch <- mean(as.numeric(subjectDatVal$vocalPitch_prePREswitch))
+    vocalPitch_preswitch <- mean(as.numeric(subjectDatVal$vocalPitch_preswitch))
+    vocalPitch_switch <- mean(as.numeric(subjectDatVal$vocalPitch_switch))
+    vocalPitch_postswitch <- mean(as.numeric(subjectDatVal$vocalPitch_postswitch))
+    percDisfluent_firstHalf <- mean(as.numeric(subjectDatVal$percDisfluent_firstHalf))
+    percDisfluent_prePREswitch <- mean(as.numeric(subjectDatVal$percDisfluent_prePREswitch))
+    percDisfluent_preswitch <- mean(as.numeric(subjectDatVal$percDisfluent_preswitch))
+    percDisfluent_switch <- mean(as.numeric(subjectDatVal$percDisfluent_switch))
+    percDisfluent_postswitch <- mean(as.numeric(subjectDatVal$percDisfluent_postswitch))
+    
+    #store output data in summary matrix
+    prelimSubjectSummaryDat[nrow(prelimSubjectSummaryDat) + 1,] <-c(id,
+                                                                    demo_b_sex,
+                                                                    demo_b_eng,
+                                                                    demo_b_langhis,
+                                                                    demo_b_ageen,
+                                                                    demo_b_diagkidnow,
+                                                                    demo_b_diateennow,
+                                                                    demo_b_diagadnow,
+                                                                    bmis_scrdVal,
+                                                                    subMood,
+                                                                    phq8_scrdTotal,
+                                                                    challengeAcc,
+                                                                    liwcScore,
+                                                                    PosOrNeg,
+                                                                    syllPerSec_firstHalf,
+                                                                    syllPerSec_prePREswitch,
+                                                                    syllPerSec_preswitch,
+                                                                    syllPerSec_switch,
+                                                                    syllPerSec_postswitch,
+                                                                    vocalPitch_firstHalf,
+                                                                    vocalPitch_prePREswitch,
+                                                                    vocalPitch_preswitch,
+                                                                    vocalPitch_switch,
+                                                                    vocalPitch_postswitch,
+                                                                    percDisfluent_firstHalf,
+                                                                    percDisfluent_prePREswitch,
+                                                                    percDisfluent_preswitch,
+                                                                    percDisfluent_switch,
+                                                                    percDisfluent_postswitch)
+    
+  }
+}
+
+### SECTION 6: OUTPUT DATA
+#write the extracted summary scores to CSV
+write.csv(prelimPassageSummaryDat, paste(out_path, prelimPassage_out, sep = "", collapse = NULL), row.names=FALSE)
+write.csv(prelimSubjectSummaryDat, paste(out_path, prelimSubject_out, sep = "", collapse = NULL), row.names=FALSE)

--- a/code/postprocessing/postprocessPrelim.R
+++ b/code/postprocessing/postprocessPrelim.R
@@ -5,9 +5,6 @@
 ### SECTION 1: SETTING UP
 library(readxl)
 
-#select participants to include in output file
-subs <- c(150001, 150004)
-
 #set up date for output file naming
 today <- Sys.Date()
 today <- format(today, "%Y%m%d")
@@ -16,18 +13,18 @@ today <- format(today, "%Y%m%d")
 #hpc
 #passagechar_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/materials/readAloud-ldt/stimuli/readAloud/readAloud-stimuli_characteristics.xlsx'
 #redcap_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/sourcedata/checked/redcap/202201v0readAloudval_DATA_2022-04-20_0854.csv'
-#challengeAcc_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220419.csv'
-#timing_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220419.csv'
-#pitch_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220419.csv''
-#disfluencies_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220419.csv'
+#challengeAcc_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220422.csv'
+#timing_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220422.csv'
+#pitch_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220422.csv''
+#disfluencies_file <- '/home/data/NDClab/datasets/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220422.csv'
 #out_path <- '/home/data/NDClab/datasets/readAloud-valence-alpha/derivatives/'
 #local
 passagechar_file <- '/Users/jalexand/github/readAloud-valence-dataset/materials/readAloud-ldt/stimuli/readAloud/readAloud-stimuli_characteristics.xlsx'
 redcap_file <- '/Users/jalexand/github/readAloud-valence-dataset/sourcedata/checked/redcap/202201v0readAloudval_DATA_2022-04-20_0854.csv'
-challengeAcc_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220419.csv'
-timing_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220419.csv'
-pitch_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220419.csv'
-disfluencies_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220419.csv'
+challengeAcc_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/readAloud_subject-level_summary_20220422.csv'
+timing_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/timing_subject-by-passage_20220422.csv'
+pitch_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/pitch_subject-by-passage_20220422.csv'
+disfluencies_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivatives/preprocessed/disfluencies_subject-by-passage_20220422.csv'
 out_path <- '/Users/jalexand/github/readAloud-valence-alpha/derivatives/'
 
 #load data files
@@ -77,7 +74,40 @@ prelimSubjectSummaryDat <- data.frame(matrix(ncol=30, nrow=0))
 colnames(prelimSubjectSummaryDat) <- colnames(prelimPassageSummaryDat)[-13] #drop only 'passage' as collapsing across passages
 prelimSubject_out <- paste("postprocess_subject-by-valence_", today, ".csv", sep="", collapse=NULL)
 
-### SECTION 2: START PARTICIPANT LOOP AND READ IN PARTICIPANT DATA
+### SECTION 2: SELECT PARTICIPANTS TO INCLUDE IN OUTPUT FILE
+#manual selection for inclusion for debugging/prelim analyses
+subs <- c(150004, 150005)
+#automatic exclusion--currently in debugging
+#subs <- c()
+#for (a in 1:nrow(challengeDat)){
+#  id <- challengeDat$id[a]
+#  redcap_row <- match(id, redcapDat$record_id)
+#  bmis_timestamp <- as.numeric(as.POSIXct(redcapDat$bmis_s1_r1_e1_timestamp[redcap_row]))
+#  readaloud_timestamp <- as.numeric(as.POSIXct(redcapDat$readaloudvalo_s1_r1_e1_timestamp[redcap_row]))
+#  taskdelay <- (readaloud_timestamp - bmis_timestamp)/60 #gives number of minutes btwn completing bmis questionnaire and completing study tasks
+#  
+#  langhis <- redcapDat$demo_b_langhis_s1_r1_e1[redcap_row]
+#  diagkidnow <- redcapDat$demo_b_diagkidnow_s1_r1_e1[redcap_row]
+#  diateennow <- redcapDat$demo_b_diateennow_s1_r1_e1[redcap_row]
+#  diagadnow <- redcapDat$demo_b_diagadnow_s1_r1_e1[redcap_row]
+#  phq8score <- redcapDat$phq8_scrdTotal_s1_r1_e1[redcap_row]
+#  
+#  challengeacc <- challengeDat$challengeAccuracy[match(id, challengeDat$id)]
+#  
+#  if(taskdelay<180 &
+#  (langhis==1 | langhis==3) &
+#  is.na(diagkidnow) & is.na(diateennow) & is.na(diagadnow) &
+#  phq8score<10 &
+#  challengeacc>0.7){
+#    subs <- c(subs, id)
+#  } else {
+#    next
+#  }
+#}
+
+
+
+### SECTION 3: START PARTICIPANT LOOP AND READ IN PARTICIPANT DATA
 for(i in 1:length(subs)){
   id <- subs[i]
   redcap_row <- match(id, redcapDat$record_id)
@@ -97,12 +127,12 @@ for(i in 1:length(subs)){
   
   challengeAcc <- challengeDat[match(id, challengeDat$id),2]
   
-  ### SECTION 3: TRIM PREPROCESSED FILES DOWN TO SUBJECT ID
+  ### SECTION 4: TRIM PREPROCESSED FILES DOWN TO SUBJECT ID
   timingDatTrim <- timingDat[timingDat$id==id,]
   pitchDatTrim <- pitchDat[timingDat$id==id,]
   disfluenciesDatTrim <- disfluenciesDat[timingDat$id==id,]
   
-  ### SECTION 4: START PASSAGE LOOP AND READ IN PASSAGE CHARACTERISTICS AND BEHAVIORAL DATA
+  ### SECTION 5: START PASSAGE LOOP AND READ IN PASSAGE CHARACTERISTICS AND BEHAVIORAL DATA
   for (j in 1:nrow(timingDatTrim)){
     passage <- timingDatTrim$passage[j]
     passagechars_row <- match(passage, passageDat$passage)
@@ -136,7 +166,7 @@ for(i in 1:length(subs)){
     percDisfluent_switch <- disfluenciesDatTrim$percDisfluent_switch[passage_disfluences_row]
     percDisfluent_postswitch <- disfluenciesDatTrim$percDisfluent_postswitch[passage_disfluences_row]
     
-    ### SECTION 4: STORE OUTPUT DATA IN SUMMARY MATRIX
+    ### SECTION 6: STORE OUTPUT DATA IN SUMMARY MATRIX
     prelimPassageSummaryDat[nrow(prelimPassageSummaryDat) + 1,] <-c(id,
                                                                     demo_b_sex,
                                                                     demo_b_eng,
@@ -172,7 +202,7 @@ for(i in 1:length(subs)){
 }
 
 
-### SECTION 5: LOOP BACK OVER SUBJECTS TO COLLAPSE prelimPassageSummaryDat ACROSS PASSAGES
+### SECTION 7: LOOP BACK OVER SUBJECTS TO COLLAPSE prelimPassageSummaryDat ACROSS PASSAGES
 for(k in 1:length(subs)){
   subjectDat <- prelimPassageSummaryDat[prelimPassageSummaryDat$id==subs[k],]
   
@@ -247,7 +277,7 @@ for(k in 1:length(subs)){
   }
 }
 
-### SECTION 6: OUTPUT DATA
+### SECTION 8: OUTPUT DATA
 #write the extracted summary scores to CSV
 write.csv(prelimPassageSummaryDat, paste(out_path, prelimPassage_out, sep = "", collapse = NULL), row.names=FALSE)
 write.csv(prelimSubjectSummaryDat, paste(out_path, prelimSubject_out, sep = "", collapse = NULL), row.names=FALSE)

--- a/code/postprocessing/postprocessPrelim.R
+++ b/code/postprocessing/postprocessPrelim.R
@@ -1,6 +1,6 @@
 # Preliminary Analyses: readAloud-valence-alpha
 # Author: Jessica M. Alexander
-# Last Updated: 2022-04-21
+# Last Updated: 2022-04-22
 
 ### SECTION 1: SETTING UP
 library(readxl)
@@ -31,7 +31,7 @@ disfluencies_file <- '/Users/jalexand/github/readAloud-valence-dataset/derivativ
 out_path <- '/Users/jalexand/github/readAloud-valence-alpha/derivatives/'
 
 #load data files
-passageDat <- read.xlsx(passagechar_file, sheet="passages")
+passageDat <- read_xlsx(passagechar_file, sheet="passages")
 redcapDat <- read.csv(redcap_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
 challengeDat <- read.csv(challengeAcc_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
 timingDat <- read.csv(timing_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
@@ -195,7 +195,7 @@ for(k in 1:length(subs)){
     challengeAcc <- subjectDatVal$challengeAcc[1]
     PosOrNeg <- switchTypes[n]
     liwcScore <- mean(as.numeric(subjectDatVal$liwcScore))
-    liwcScore <- mean(as.numeric(subjectDatVal$warrinerAvg))
+    warrinerAvg <- mean(as.numeric(subjectDatVal$warrinerAvg))
     syllPerSec_firstHalf <- mean(as.numeric(subjectDatVal$syllPerSec_firstHalf))
     syllPerSec_prePREswitch <- mean(as.numeric(subjectDatVal$syllPerSec_prePREswitch))
     syllPerSec_preswitch <- mean(as.numeric(subjectDatVal$syllPerSec_preswitch))

--- a/code/postprocessing/postprocessPrelim.R
+++ b/code/postprocessing/postprocessPrelim.R
@@ -39,7 +39,7 @@ pitchDat <- read.csv(pitch_file, stringsAsFactors = FALSE, na.strings=c("", "NA"
 disfluenciesDat <- read.csv(disfluencies_file, stringsAsFactors = FALSE, na.strings=c("", "NA"))
 
 #create dataframes for storing output data and define output file name
-prelimPassageSummaryDat <- data.frame(matrix(ncol=30, nrow=0))
+prelimPassageSummaryDat <- data.frame(matrix(ncol=31, nrow=0))
 colnames(prelimPassageSummaryDat) <- c("id",
                                        "demo_b_sex",
                                        "demo_b_eng",
@@ -53,8 +53,9 @@ colnames(prelimPassageSummaryDat) <- c("id",
                                        "phq8_scrdTotal",
                                        "challengeAcc",
                                        "passage",
-                                       "liwcScore",
                                        "PosOrNeg",
+                                       "liwcScore",
+                                       "warrinerAvg",
                                        "syllPerSec_firstHalf",
                                        "syllPerSec_prePREswitch",
                                        "syllPerSec_preswitch",
@@ -72,7 +73,7 @@ colnames(prelimPassageSummaryDat) <- c("id",
                                        "percDisfluent_postswitch")
 prelimPassage_out <- paste("postprocess_subject-by-passage_", today, ".csv", sep="", collapse=NULL)
 
-prelimSubjectSummaryDat <- data.frame(matrix(ncol=29, nrow=0))
+prelimSubjectSummaryDat <- data.frame(matrix(ncol=30, nrow=0))
 colnames(prelimSubjectSummaryDat) <- colnames(prelimPassageSummaryDat)[-13] #drop only 'passage' as collapsing across passages
 prelimSubject_out <- paste("postprocess_subject-by-valence_", today, ".csv", sep="", collapse=NULL)
 
@@ -105,8 +106,14 @@ for(i in 1:length(subs)){
   for (j in 1:nrow(timingDatTrim)){
     passage <- timingDatTrim$passage[j]
     passagechars_row <- match(passage, passageDat$passage)
-    liwcScore <- passageDat$emoToneALL[passagechars_row]
     PosOrNeg <- passageDat$switchType[passagechars_row]
+    if (PosOrNeg == "pos2neg"){
+      liwcScore <- passageDat$emoTonePOS[passagechars_row]
+      warrinerAvg <- passageDat$posAvgWAR[passagechars_row]
+    } else {
+      liwcScore <- passageDat$emoToneNEG[passagechars_row]
+      warrinerAvg <- passageDat$negAvgWAR[passagechars_row]
+    }
     
     passage_timing_row <- match(passage, timingDatTrim$passage)
     syllPerSec_firstHalf <- timingDatTrim$syllPerSec_firstHalf[passage_timing_row]
@@ -143,8 +150,9 @@ for(i in 1:length(subs)){
                                                                     phq8_scrdTotal,
                                                                     challengeAcc,
                                                                     passage,
-                                                                    liwcScore,
                                                                     PosOrNeg,
+                                                                    liwcScore,
+                                                                    warrinerAvg,
                                                                     syllPerSec_firstHalf,
                                                                     syllPerSec_prePREswitch,
                                                                     syllPerSec_preswitch,
@@ -185,8 +193,9 @@ for(k in 1:length(subs)){
     subMood <- subjectDatVal$subMood[1]
     phq8_scrdTotal <- subjectDatVal$phq8_scrdTotal[1]
     challengeAcc <- subjectDatVal$challengeAcc[1]
-    liwcScore <- mean(as.numeric(subjectDatVal$liwcScore))
     PosOrNeg <- switchTypes[n]
+    liwcScore <- mean(as.numeric(subjectDatVal$liwcScore))
+    liwcScore <- mean(as.numeric(subjectDatVal$warrinerAvg))
     syllPerSec_firstHalf <- mean(as.numeric(subjectDatVal$syllPerSec_firstHalf))
     syllPerSec_prePREswitch <- mean(as.numeric(subjectDatVal$syllPerSec_prePREswitch))
     syllPerSec_preswitch <- mean(as.numeric(subjectDatVal$syllPerSec_preswitch))
@@ -216,8 +225,9 @@ for(k in 1:length(subs)){
                                                                     subMood,
                                                                     phq8_scrdTotal,
                                                                     challengeAcc,
-                                                                    liwcScore,
                                                                     PosOrNeg,
+                                                                    liwcScore,
+                                                                    warrinerAvg,
                                                                     syllPerSec_firstHalf,
                                                                     syllPerSec_prePREswitch,
                                                                     syllPerSec_preswitch,


### PR DESCRIPTION
This contains two scripts (in somewhat odd locations as I wasn't sure where best to place them, guidance requested!):

1. postprocessPrelim: this pulls together the outputs from the preprocessing scripts PRed under the dataset repo into a format amenable to the planned preliminary, valence-related analyses
2. analysisPrelim: this is my first attempt to set up a roadmap for simple plots and stats that deal with Hypotheses 1a, 1b, and 2 (the valence-related ones).  Note that since both valence and mood can be considered categorical or continuous variables, I've taken a stab at both options.

The current scripts **do not** handle confounds.  I will need some guidance on how we go about controlling for things like log frequency, etc. generally in such models. 🙇‍♀️ 

Thank you!
